### PR TITLE
Gradients in the choices

### DIFF
--- a/fields/acf-base.php
+++ b/fields/acf-base.php
@@ -73,6 +73,18 @@
 	private function get_svg_file_path() {
 		return apply_filters( 'acf_svg_icon_filepath', false );
 	}
+	
+	/**
+	 * Get the allowed tags to parse icon's ids
+	 * Passed directly to strip_tags
+	 * @link http://php.net/manual/en/function.strip-tags.php
+	 *
+	 * @return string
+	 * @author david-treblig
+	 */
+	private function get_allowed_svg_tags() {
+		return apply_filters( 'acf_svg_icon_svg_parse_tags', '<symbol><g>' );
+	}
 
 
 	/**
@@ -106,7 +118,8 @@
 
 		// If not extract them from the CSS file.
 		$contents = file_get_contents( $file_path );
-		preg_match_all( '#id="(\S+)"#', strip_tags($contents, '<symbol><g>'), $svg );
+		$tags = $this->get_allowed_svg_tags();
+		preg_match_all( '#id="(\S+)"#', strip_tags($contents, $tags), $svg );
 		array_shift( $svg );
 
 		foreach ( $svg[0] as $id ) {

--- a/fields/acf-base.php
+++ b/fields/acf-base.php
@@ -106,7 +106,7 @@
 
 		// If not extract them from the CSS file.
 		$contents = file_get_contents( $file_path );
-		preg_match_all( '#id="(\S+)"#', $contents, $svg );
+		preg_match_all( '#id="(\S+)"#', strip_tags($contents, '<symbol><g>'), $svg );
 		array_shift( $svg );
 
 		foreach ( $svg[0] as $id ) {


### PR DESCRIPTION
Gradients get grabbed by the regex right now because of the too general ```id="(\S+)"``` regex. Gradients need ids so they can get referenced later and when you have gradients in your "defs", it gets grabbed as well. At first, I wanted to resolve this problem by grabbing only the IDs that aren't between ```defs``` with the regex, but that gets complicated, so I went with the more simple ```strip_tags``` route by keeping only ```symbol``` and ```g``` which are the two most popular ways to build svg icon sprites.

Here's an example svg sprite that would cause to have an empty choice because of the gradient in ```defs``` : 
```xml
<svg class="svg-icons-definitions" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
    <defs>
        <linearGradient x1="33.236%" y1="-36.335%" x2="66.808%" y2="-36.179%" id="0a"><stop stop-color="#EDF0F7" offset="0%"></stop><stop stop-color="#FAFAFA" offset="100%"></stop></linearGradient><linearGradient x1="44.849%" y1="-105.823%" x2="55.16%" y2="-105.541%" id="0b"><stop stop-color="#7045FF" offset="0%"></stop><stop stop-color="#36BFEF" offset="100%"></stop></linearGradient>
    </defs>
    <symbol id="icon-base" viewBox="0 0 180 111">
        <title>base</title><g fill-rule="nonzero" fill="none"><g fill="url(#0a)"><path d="M0 52.7L89.8.6 180 52.9l-89.7 52z"></path><g transform="translate(0 .6)"><path d="M0 52.1L89.8 0 180 52.3l-89.7 52z"></path><path d="M90.3 104.3L0 52.1 89.8 0 180 52.3z"></path></g></g><path d="M180 .2v5.5L90.3 57.8 0 5.6.1 0l90.2 52.2z" transform="translate(0 52.7)" fill="url(#0b)"></path></g>
    </symbol>
</svg>
```