### PR TITLE
Add filter to allow adding single files (that aren't sprites)

### DIFF
--- a/fields/acf-base.php
+++ b/fields/acf-base.php
@@ -108,6 +108,7 @@ class acf_field_svg_icon extends acf_field {
 		 * @since 2.0.0
 		 */
 		$media_svg_files = $this->get_medias_svg();
+		$media_svg_files = apply_filters( 'acf_svg_icon_wp_media_svgs' , $media_svg_files);
 
 		/**
 		 * The path to the svg file.


### PR DESCRIPTION
Hi! Me again years later. I started giving up on using sprites nowadays to use simple svg includes so I needed a way to pull icon files from a folder. Some other plugins say they're doing this, but I had compatibility issues and by reading the code of your plugin again, I realized we could simple filter the media files to add our own. Here's how I'm using it right now, but feel free to tell me how to rework this and I'll adapt the pull request.

```add_filter( 'acf_svg_icon_wp_media_svgs', function ( $svg ) {
    $files = glob(get_stylesheet_directory() . '/dist/icons/*.svg');
    foreach ($files as $key => $file) {
        $svg[] = [
            'type'     => 'media',
            'id'       => basename($file),
            'file'     => $file,
            'file_url' => get_stylesheet_directory_uri() . '/dist/icons/' . basename($file),
        ];
    }
    return $svg;
});```