### PR TITLE
Hooks for cache flush changed to two that works

### DIFF
--- a/fields/acf-base.php
+++ b/fields/acf-base.php
@@ -24,7 +24,9 @@ class acf_field_svg_icon extends acf_field {
 		parent::__construct();
 
 		// Hooks !
-		add_action( 'save_post_attachment', array( $this, 'save_post_attachment' ) );
+		add_action( 'add_attachment', array( $this, 'save_post_attachment' ) );
+		add_action( 'edit_attachment', array( $this, 'save_post_attachment' ) );
+
 	}
 
 	/**


### PR DESCRIPTION
**Action** `save_post_attachment` doesn't seem to exists and the cache flush in the **function** `save_post_attachment` is highly necessary.