### PR TITLE
chore: release version 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ If you gonna change some JS or CSS, we use GULP in order to uglify and minify as
 
 ## Changelog ##
 
+### 2.2.0 - 19 May 2026
+* FIX : Invalid plugin's SVG cache when a SVG is added or removed from the media library
+* FEATURE : Add admin bar button to flush plugin's SVG cache
+
 ### 2.1.3 - 17 Jul 2023
 * FEATURE : Skip media type for displaying svgs as we use the URL
 

--- a/acf-svg-icon.php
+++ b/acf-svg-icon.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Advanced Custom Fields: SVG Icon
-Version: 2.1.3
+Version: 2.2.0
 Plugin URI: http://www.beapi.fr
 Description: Add an ACF SVG icon selector.
 Author: BE API Technical team
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die();
 }
 
-define( 'ACF_SVG_ICON_VER', '2.1.3' );
+define( 'ACF_SVG_ICON_VER', '2.2.0' );
 define( 'ACF_SVG_ICON_URL', plugin_dir_url( __FILE__ ) );
 define( 'ACF_SVG_ICON_DIR', plugin_dir_path( __FILE__ ) );
 define( 'ACF_SVG_ICON_CACHE_KEY', 'acf_svg_icon_files' );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acf-svg-icon",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "ACF SVG icon field.",
   "author": "Be API",
   "devDependencies": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: updates version strings and README changelog without changing runtime behavior.
> 
> **Overview**
> Bumps the plugin/package version from `2.1.3` to `2.2.0` in `acf-svg-icon.php` and `package.json`.
> 
> Updates `README.md` changelog with the `2.2.0` release notes (SVG cache invalidation fix and an admin-bar cache-flush button).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 844617baafd8b1a3c6381833e4417b7edbb2489d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->